### PR TITLE
Update ServerListener.java

### DIFF
--- a/transaction-springcloud/src/main/java/com/codingapi/tx/springcloud/listener/ServerListener.java
+++ b/transaction-springcloud/src/main/java/com/codingapi/tx/springcloud/listener/ServerListener.java
@@ -30,4 +30,8 @@ public class ServerListener implements ApplicationListener<EmbeddedServletContai
     public int getPort() {
         return this.serverPort;
     }
+    
+    public void setServerPort(int serverPort) {
+        this.serverPort = serverPort;
+    }
 }


### PR DESCRIPTION
springcloud 打成war包执行的时候，并不走EmbeddedServletContainerInitializedEvent这个事件，所以可以监听ApplicationReadyEvent事件，将ServerListener，InitService注入新的监听器中启动客户端。springcloud的端口号一般都会配置，所以可以从配置文件中获取。第一次用github不知道对不对。