### PR TITLE
FIX 当 dtx timeout.时抛出LcnBusinessException异常之后 第二次ex.getCause() 会抛java…

### DIFF
--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/core/template/TransactionControlTemplate.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/core/template/TransactionControlTemplate.java
@@ -143,6 +143,7 @@ public class TransactionControlTemplate {
             txLogger.txTrace(
                     groupId, unitId, "notify group > transaction type: {}, state: {}.", transactionType, state);
             if (globalContext.isDTXTimeout()) {
+                txLogger.trace(groupId, unitId, Transactions.TE, "dtx timeout.");
                 throw new LcnBusinessException("dtx timeout.");
             }
             state = reliableMessenger.notifyGroup(groupId, state);
@@ -153,7 +154,7 @@ public class TransactionControlTemplate {
             dtxExceptionHandler.handleNotifyGroupMessageException(Arrays.asList(groupId, state, unitId, transactionType), e);
         } catch (LcnBusinessException e) {
             // 关闭事务组失败
-            dtxExceptionHandler.handleNotifyGroupBusinessException(Arrays.asList(groupId, state, unitId, transactionType), e.getCause());
+            dtxExceptionHandler.handleNotifyGroupBusinessException(Arrays.asList(groupId, state, unitId, transactionType), e);
         }
         txLogger.txTrace(groupId, unitId, "notify group exception state {}.", state);
     }

--- a/txlcn-txmsg-netty/src/main/java/com/codingapi/txlcn/txmsg/netty/bean/SocketManager.java
+++ b/txlcn-txmsg-netty/src/main/java/com/codingapi/txlcn/txmsg/netty/bean/SocketManager.java
@@ -172,7 +172,7 @@ public class SocketManager {
      * @param moduleName 模块名称
      * @return remoteKeys
      */
-    public List<String> removeKeys(String moduleName) {
+    public List<String> remoteKeys(String moduleName) {
         List<String> allKeys = new ArrayList<>();
         for (Channel channel : channels) {
             if (moduleName.equals(getModuleName(channel))) {

--- a/txlcn-txmsg-netty/src/main/java/com/codingapi/txlcn/txmsg/netty/impl/NettyRpcClient.java
+++ b/txlcn-txmsg-netty/src/main/java/com/codingapi/txlcn/txmsg/netty/impl/NettyRpcClient.java
@@ -93,7 +93,7 @@ public class NettyRpcClient extends RpcClient {
 
     @Override
     public List<String> remoteKeys(String moduleName) {
-        return SocketManager.getInstance().removeKeys(moduleName);
+        return SocketManager.getInstance().remoteKeys(moduleName);
     }
 
 


### PR DESCRIPTION
FIX 当 dtx timeout.时抛出LcnBusinessException异常之后 第二次ex.getCause() 会抛java.lang.NullPointException
![image](https://user-images.githubusercontent.com/20358122/60342639-9dc46d80-99e4-11e9-973d-a4d2a280d20a.png)
![image](https://user-images.githubusercontent.com/20358122/60342714-ca788500-99e4-11e9-93d3-7a864782754d.png)
