### PR TITLE
#509 TC模块事务日志适配

### DIFF
--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/jdbc/log/LogExecutor.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/jdbc/log/LogExecutor.java
@@ -15,4 +15,9 @@ public interface LogExecutor {
 
     String delete(List<Long> ids);
 
+    /**
+     * 返回数据库找不到表报错时的VendorCode码
+     * @return
+     */
+    int getTableNotFindErrorCode();
 }

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/jdbc/log/MysqlLogExecutor.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/jdbc/log/MysqlLogExecutor.java
@@ -18,12 +18,26 @@ public class MysqlLogExecutor implements LogExecutor {
 
     @Override
     public String create() {
-        return null;
+        return "\n" +
+                "CREATE TABLE `transaction_log` (\n" +
+                "  `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT ' ',\n" +
+                "  `group_id` varchar(40) DEFAULT NULL,\n" +
+                "  `sql` varchar(255) DEFAULT NULL,\n" +
+                "  `time` bigint(20) DEFAULT NULL,\n" +
+                "  `flag` int(1) DEFAULT NULL,\n" +
+                "  PRIMARY KEY (`id`)\n" +
+                ") ENGINE=InnoDB DEFAULT CHARSET=latin1;\n" +
+                "\n" ;
     }
 
     @Override
     public String delete(List<Long> ids) {
         String id = Joiner.on(",").join(ids);
         return "delete from `transaction_log` where id in ("+id+")";
+    }
+
+    @Override
+    public int getTableNotFindErrorCode() {
+        return 1146;
     }
 }


### PR DESCRIPTION
#509 TC模块事务日志适配  …
LogExecutor.java 中增加了获取数据库建表失败时的报错编码借口
TransactionLogExecutor 中如果在插入日志时报没有日志表错误,就创建日志表