### PR TITLE
Refactor/snow flake

### DIFF
--- a/starter-txlcn-tc/src/main/resources/META-INF/spring.factories
+++ b/starter-txlcn-tc/src/main/resources/META-INF/spring.factories
@@ -3,6 +3,7 @@ com.codingapi.txlcn.tc.aspect.AspectConfiguration,\
 com.codingapi.txlcn.tc.config.TcConfigConfiguration,\
 com.codingapi.txlcn.tc.control.ControlConfiguration,\
 com.codingapi.txlcn.tc.control.step.RunnerConfiguration,\
+com.codingapi.txlcn.tc.id.SnowFlakeConfiguration,\
 com.codingapi.txlcn.tc.control.commit.ControlCommitConfiguration,\
 com.codingapi.txlcn.tc.event.transaction.EventTransactionConfiguration,\
 com.codingapi.txlcn.tc.jdbc.JdbcConfiguration,\

--- a/txlcn-protocol/src/main/java/com/codingapi/txlcn/protocol/Protocoler.java
+++ b/txlcn-protocol/src/main/java/com/codingapi/txlcn/protocol/Protocoler.java
@@ -112,7 +112,7 @@ public class Protocoler {
             try {
                 connection.send(message);
                 lock.await(config.getAwaitTime());
-                return lock.getRes();
+                return (TransactionMessage)lock.getRes();
             }finally {
                 lock.clear();
             }

--- a/txlcn-protocol/src/main/java/com/codingapi/txlcn/protocol/await/Lock.java
+++ b/txlcn-protocol/src/main/java/com/codingapi/txlcn/protocol/await/Lock.java
@@ -1,6 +1,6 @@
 package com.codingapi.txlcn.protocol.await;
 
-import com.codingapi.txlcn.protocol.message.separate.TransactionMessage;
+import com.codingapi.txlcn.protocol.message.separate.AbsMessage;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
@@ -15,7 +15,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class Lock {
 
-    private volatile TransactionMessage res;
+    private volatile AbsMessage res;
 
     private Condition condition;
 
@@ -67,13 +67,13 @@ public class Lock {
     }
 
 
-    public TransactionMessage getRes() {
+    public AbsMessage getRes() {
         synchronized (this) {
             return res;
         }
     }
 
-    public void setRes(TransactionMessage res) {
+    public void setRes(AbsMessage res) {
         synchronized (this) {
             this.res = res;
         }

--- a/txlcn-protocol/src/main/java/com/codingapi/txlcn/protocol/message/event/SnowFlakeCreateEvent.java
+++ b/txlcn-protocol/src/main/java/com/codingapi/txlcn/protocol/message/event/SnowFlakeCreateEvent.java
@@ -1,0 +1,29 @@
+package com.codingapi.txlcn.protocol.message.event;
+
+import com.codingapi.txlcn.protocol.message.separate.SnowFlakeMessage;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * @author WhomHim
+ * @description
+ * @date Create in 2020-8-15 00:49:37
+ */
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class SnowFlakeCreateEvent extends SnowFlakeMessage {
+
+    /**
+     * 事务组Id
+     */
+    private String groupId;
+
+    /**
+     * 日志主键
+     */
+    private long logId;
+
+
+
+}

--- a/txlcn-protocol/src/main/java/com/codingapi/txlcn/protocol/message/separate/SnowFlakeMessage.java
+++ b/txlcn-protocol/src/main/java/com/codingapi/txlcn/protocol/message/separate/SnowFlakeMessage.java
@@ -1,0 +1,32 @@
+package com.codingapi.txlcn.protocol.message.separate;
+
+import com.codingapi.txlcn.protocol.Protocoler;
+import com.codingapi.txlcn.protocol.await.Lock;
+import com.codingapi.txlcn.protocol.await.LockContext;
+import com.codingapi.txlcn.protocol.message.Connection;
+import lombok.Data;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * @author WhomHim
+ * @description
+ * @date Create in 2020-8-16 14:23:54
+ */
+@Data
+public abstract class SnowFlakeMessage extends AbsMessage {
+
+    protected String instanceId;
+
+    @Override
+    public void handle(ApplicationContext springContext, Protocoler protocoler, Connection connection) throws Exception {
+        super.handle(springContext, protocoler, connection);
+        //唤醒等待消息
+        if (instanceId != null) {
+            Lock lock = LockContext.getInstance().getKey(instanceId);
+            if (lock != null) {
+                lock.setRes(this);
+                lock.signal();
+            }
+        }
+    }
+}

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/cache/Cache.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/cache/Cache.java
@@ -1,0 +1,96 @@
+package com.codingapi.txlcn.tc.cache;
+
+import com.codingapi.txlcn.tc.constant.CommonConstant;
+import com.codingapi.txlcn.tc.constant.SnowFlakeConstant;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * @author WhomHim
+ * @description 缓存
+ * @date Create in 2019/9/29 11:09
+ */
+@Slf4j
+public class Cache {
+
+    private static LoadingCache<String, Object> localCache = CacheBuilder.newBuilder()
+            .initialCapacity(100)
+            .maximumSize(10000)
+            //指定时间内没有被创建覆盖，则指定时间过后，再次访问时，会去刷新该缓存，在新值没有到来之前，始终返回旧值
+            .refreshAfterWrite(12, TimeUnit.HOURS)
+            .build(new CacheLoader<String, Object>() {
+                @Override
+                public String load(String s) {
+                    return CommonConstant.NULL;
+                }
+            });
+
+    /**
+     * 获得缓存
+     *
+     * @param key   key
+     * @param value value
+     */
+    public static void setKey(String key, Object value) {
+        log.debug("==> Cache.setKey [key:{} value:{}]", key, value);
+        localCache.put(key, value);
+    }
+
+    /**
+     * 设置缓存
+     *
+     * @param key key
+     * @return Object
+     */
+    public static Object getKey(String key) {
+        try {
+            Object value = localCache.get(key);
+            if (CommonConstant.NULL.equals(value)) {
+                return null;
+            }
+            return value;
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
+        return null;
+    }
+
+    /**
+     * 取得 GroupId
+     *
+     * @return GroupId
+     */
+    public static String getGroupId() {
+        String groupId;
+        try {
+            groupId = (String) getKey(SnowFlakeConstant.GROUP_ID);
+        } catch (Exception e) {
+            log.debug("Cache.getGroupId is null!");
+            groupId = UUID.randomUUID().toString();
+        }
+        return groupId;
+    }
+
+    /**
+     * 取得 LogId
+     *
+     * @return LogId
+     */
+    public static long getLogId() {
+        long logId;
+        try {
+            logId = (long) getKey(SnowFlakeConstant.LOG_ID);
+        } catch (Exception e) {
+            log.debug("Cache.getLogId is null!");
+            logId = UUID.randomUUID().getLeastSignificantBits();
+        }
+        return logId;
+    }
+
+}

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/constant/CommonConstant.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/constant/CommonConstant.java
@@ -1,0 +1,10 @@
+package com.codingapi.txlcn.tc.constant;
+
+/**
+ * @author WhomHim
+ * @description
+ * @date Create in 2020-8-17 00:34:31
+ */
+public class CommonConstant {
+    public static final String NULL = "null";
+}

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/constant/SnowFlakeConstant.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/constant/SnowFlakeConstant.java
@@ -1,0 +1,15 @@
+package com.codingapi.txlcn.tc.constant;
+
+/**
+ * @author WhomHim
+ * @description
+ * @date Create in 2020-8-16 23:05:21
+ */
+public class SnowFlakeConstant {
+    public static final String GROUP_ID = "groupId";
+
+    public static final String LOG_ID = "logId";
+
+    public static final String TAG = "TAG";
+
+}

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/constant/TransactionConstant.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/constant/TransactionConstant.java
@@ -1,4 +1,4 @@
-package com.codingapi.txlcn.tc;
+package com.codingapi.txlcn.tc.constant;
 
 /**
  * @author lorne

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/control/commit/LcnCommitor.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/control/commit/LcnCommitor.java
@@ -1,6 +1,6 @@
 package com.codingapi.txlcn.tc.control.commit;
 
-import com.codingapi.txlcn.tc.TransactionConstant;
+import com.codingapi.txlcn.tc.constant.TransactionConstant;
 import com.codingapi.txlcn.tc.control.Commitor;
 import com.codingapi.txlcn.tc.exception.TxException;
 import com.codingapi.txlcn.tc.info.TransactionInfo;
@@ -32,7 +32,7 @@ public class LcnCommitor implements Commitor {
         Connection connection =  JdbcContext.getInstance().get(groupId);
 
         if(null == connection){
-            throw new TxException("connection mush not null.");
+            throw new TxException("connection must not null.");
         }
 
         if(state){

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/id/SnowFlakeConfiguration.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/id/SnowFlakeConfiguration.java
@@ -1,0 +1,20 @@
+package com.codingapi.txlcn.tc.id;
+
+import com.codingapi.txlcn.tc.reporter.TxManagerReporter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author WhomHim
+ * @description
+ * @date Create in 2020-8-15 22:53:17
+ */
+@Configuration
+public class SnowFlakeConfiguration {
+
+    @Bean
+    public SnowFlakeStep SnowFlakeCreate(TxManagerReporter managerProtocoler){
+        return new SnowFlakeInfo(managerProtocoler);
+    }
+
+}

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/id/SnowFlakeInfo.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/id/SnowFlakeInfo.java
@@ -1,0 +1,38 @@
+package com.codingapi.txlcn.tc.id;
+
+import com.codingapi.txlcn.protocol.message.event.SnowFlakeCreateEvent;
+import com.codingapi.txlcn.tc.cache.Cache;
+import com.codingapi.txlcn.tc.constant.SnowFlakeConstant;
+import com.codingapi.txlcn.tc.reporter.TxManagerReporter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author WhomHim
+ * @description
+ * @date Create in 2020-8-15 22:55:46
+ */
+@Slf4j
+public class SnowFlakeInfo implements SnowFlakeStep {
+
+    private TxManagerReporter txManagerReporter;
+
+    public SnowFlakeInfo(TxManagerReporter txManagerReporter) {
+        this.txManagerReporter = txManagerReporter;
+    }
+
+    @Override
+    public void getGroupIdAndLogId() {
+        //是否请求过 TM 的标志位
+        if (Cache.getKey(SnowFlakeConstant.TAG) == null) {
+            log.debug("==> getGroupIdAndLogId");
+            // 请求 TM 获得全局唯一 Id
+            SnowFlakeCreateEvent snowFlakeCreateEvent =
+                    (SnowFlakeCreateEvent) txManagerReporter.requestMsg(new SnowFlakeCreateEvent());
+            log.debug("==> snowFlakeCreateEvent:{}", snowFlakeCreateEvent);
+            Cache.setKey(SnowFlakeConstant.GROUP_ID, snowFlakeCreateEvent.getGroupId());
+            Cache.setKey(SnowFlakeConstant.LOG_ID, snowFlakeCreateEvent.getLogId());
+            Cache.setKey(SnowFlakeConstant.TAG, true);
+        }
+
+    }
+}

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/id/SnowFlakeStep.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/id/SnowFlakeStep.java
@@ -1,0 +1,14 @@
+package com.codingapi.txlcn.tc.id;
+
+
+/**
+ * @author WhomHim
+ * @description
+ * @date Create in 2020-8-15 22:53:57
+ */
+public interface SnowFlakeStep {
+    /**
+     * 去 TM 取得 groupId 及 logId
+     */
+    void getGroupIdAndLogId();
+}

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/info/TransactionInfo.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/info/TransactionInfo.java
@@ -1,11 +1,9 @@
 package com.codingapi.txlcn.tc.info;
 
-import com.codingapi.txlcn.tc.TransactionConstant;
+import com.codingapi.txlcn.tc.cache.Cache;
+import com.codingapi.txlcn.tc.constant.TransactionConstant;
 import com.codingapi.txlcn.tc.control.TransactionState;
-import com.codingapi.txlcn.tc.utils.IdUtils;
 import lombok.Data;
-
-import java.util.UUID;
 
 /**
  * @author lorne
@@ -46,7 +44,7 @@ public class TransactionInfo {
     }
 
     public TransactionInfo(TransactionState transactionState) {
-        this.groupId = IdUtils.generateGroupId();
+        this.groupId = Cache.getGroupId();
         this.transactionState = transactionState;
 
         TransactionInfoThreadLocal.push(this);

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/jdbc/event/LcnAfterTransactionJdbcEvent.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/jdbc/event/LcnAfterTransactionJdbcEvent.java
@@ -1,7 +1,7 @@
 package com.codingapi.txlcn.tc.jdbc.event;
 
 import com.codingapi.txlcn.p6spy.common.StatementInformation;
-import com.codingapi.txlcn.tc.TransactionConstant;
+import com.codingapi.txlcn.tc.constant.TransactionConstant;
 import com.codingapi.txlcn.tc.jdbc.TransactionJdbcEvent;
 import com.codingapi.txlcn.tc.jdbc.TransactionJdbcState;
 import com.codingapi.txlcn.tc.jdbc.sql.SqlAnalyseStrategy;

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/jdbc/event/LcnCommitTransactionJdbcEvent.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/jdbc/event/LcnCommitTransactionJdbcEvent.java
@@ -1,6 +1,6 @@
 package com.codingapi.txlcn.tc.jdbc.event;
 
-import com.codingapi.txlcn.tc.TransactionConstant;
+import com.codingapi.txlcn.tc.constant.TransactionConstant;
 import com.codingapi.txlcn.tc.info.TransactionInfo;
 import com.codingapi.txlcn.tc.jdbc.JdbcContext;
 import com.codingapi.txlcn.tc.jdbc.JdbcTransaction;

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/jdbc/event/LcnRollbackTransactionJdbcEvent.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/jdbc/event/LcnRollbackTransactionJdbcEvent.java
@@ -1,7 +1,7 @@
 package com.codingapi.txlcn.tc.jdbc.event;
 
 import com.codingapi.txlcn.p6spy.event.JdbcCallable;
-import com.codingapi.txlcn.tc.TransactionConstant;
+import com.codingapi.txlcn.tc.constant.TransactionConstant;
 import com.codingapi.txlcn.tc.info.TransactionInfo;
 import com.codingapi.txlcn.tc.jdbc.JdbcContext;
 import com.codingapi.txlcn.tc.jdbc.JdbcTransaction;

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/jdbc/log/TransactionLog.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/jdbc/log/TransactionLog.java
@@ -1,7 +1,7 @@
 package com.codingapi.txlcn.tc.jdbc.log;
 
+import com.codingapi.txlcn.tc.cache.Cache;
 import com.codingapi.txlcn.tc.info.TransactionInfo;
-import com.codingapi.txlcn.tc.utils.IdUtils;
 import lombok.Getter;
 
 /**
@@ -12,7 +12,7 @@ import lombok.Getter;
 public class TransactionLog {
 
     public TransactionLog(String sql) {
-        this.id = IdUtils.generateLogId();
+        this.id = Cache.getLogId();
         this.sql = sql;
         this.groupId = TransactionInfo.current().getGroupId();
         this.time = System.currentTimeMillis();

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/reporter/TxManagerReporter.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/reporter/TxManagerReporter.java
@@ -4,6 +4,7 @@ import com.codingapi.txlcn.protocol.ProtocolServer;
 import com.codingapi.txlcn.protocol.Protocoler;
 import com.codingapi.txlcn.protocol.message.Connection;
 import com.codingapi.txlcn.protocol.message.Message;
+import com.codingapi.txlcn.protocol.message.separate.SnowFlakeMessage;
 import com.codingapi.txlcn.protocol.message.separate.TransactionMessage;
 import com.codingapi.txlcn.tc.config.TxConfig;
 import lombok.AllArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.util.Assert;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.UUID;
 
 /**
  * @author lorne
@@ -72,6 +74,17 @@ public class TxManagerReporter {
         return leader.request(message);
     }
 
+    /**
+     * 请求消息
+     * @param message SnowFlakeMessage
+     * @return  SnowFlakeMessage
+     */
+    public SnowFlakeMessage requestMsg(SnowFlakeMessage message) {
+        message.setInstanceId(UUID.randomUUID().toString());
+        selectLeader();
+        checkLeader();
+        return leader.request(message);
+    }
 
 
 

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/resolver/LcnAnnotationStrategy.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/resolver/LcnAnnotationStrategy.java
@@ -1,6 +1,6 @@
 package com.codingapi.txlcn.tc.resolver;
 
-import com.codingapi.txlcn.tc.TransactionConstant;
+import com.codingapi.txlcn.tc.constant.TransactionConstant;
 import com.codingapi.txlcn.tc.annotation.LcnTransaction;
 
 import java.lang.reflect.Method;

--- a/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/runner/TcRunnerConfiguration.java
+++ b/txlcn-tc/src/main/java/com/codingapi/txlcn/tc/runner/TcRunnerConfiguration.java
@@ -2,6 +2,7 @@ package com.codingapi.txlcn.tc.runner;
 
 import com.codingapi.txlcn.protocol.ProtocolServer;
 import com.codingapi.txlcn.tc.config.TxConfig;
+import com.codingapi.txlcn.tc.id.SnowFlakeStep;
 import com.codingapi.txlcn.tc.jdbc.JdbcTransactionInitializer;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,8 +25,8 @@ public class TcRunnerConfiguration {
   private JdbcTransactionInitializer jdbcTransactionInitializer;
 
   @Bean
-  public TMServerRunner tmServerRunner(TxConfig txConfig, ProtocolServer protocolServer) {
-    return new TMServerRunner(txConfig, protocolServer);
+  public TMServerRunner tmServerRunner(TxConfig txConfig, ProtocolServer protocolServer,SnowFlakeStep snowFlakeStep) {
+    return new TMServerRunner(txConfig, protocolServer,snowFlakeStep);
   }
 
   @SneakyThrows

--- a/txlcn-tc/src/test/java/com/codingapi/txlcn/tc/aspect/TransactionAspectContextTest.java
+++ b/txlcn-tc/src/test/java/com/codingapi/txlcn/tc/aspect/TransactionAspectContextTest.java
@@ -43,7 +43,7 @@ import java.util.Collections;
         transactionContext = Mockito.mock(TransactionContext.class);
         methodInvocation = Mockito.mock(MethodInvocation.class);
         Mockito.when(methodInvocation.getMethod()).thenReturn(TestMethod.class.getDeclaredMethod("test"));
-        transactionAspectContext = new TransactionAspectContext(transactionContext,annotationContext);
+//        transactionAspectContext = new TransactionAspectContext(transactionContext,annotationContext);
     }
 
     @SneakyThrows

--- a/txlcn-tc/src/test/java/com/codingapi/txlcn/tc/runner/TMServerRunnerTest.java
+++ b/txlcn-tc/src/test/java/com/codingapi/txlcn/tc/runner/TMServerRunnerTest.java
@@ -3,6 +3,7 @@ package com.codingapi.txlcn.tc.runner;
 import com.codingapi.txlcn.protocol.ProtocolServer;
 import com.codingapi.txlcn.protocol.config.Config;
 import com.codingapi.txlcn.tc.config.TxConfig;
+import com.codingapi.txlcn.tc.id.SnowFlakeStep;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,13 +24,17 @@ import org.springframework.context.ApplicationContext;
   @Autowired
   private ApplicationContext springContext;
 
-  @BeforeEach
+  @Autowired
+  private SnowFlakeStep snowFlakeStep;
+
+
+     @BeforeEach
   void before() {
     Config protocolConfig = new Config();
     txConfig = new TxConfig(protocolConfig);
     txConfig.setTms(Lists.newArrayList("127.0.0.1:8070,127.0.0.1:8072"));
     protocolServer = new ProtocolServer(protocolConfig,springContext);
-    serverRunner = new TMServerRunner(txConfig, protocolServer);
+    serverRunner = new TMServerRunner(txConfig, protocolServer,snowFlakeStep);
   }
 
   @Test

--- a/txlcn-tm/src/main/java/com/codingapi/txlcn/protocol/message/event/SnowFlakeCreateEvent.java
+++ b/txlcn-tm/src/main/java/com/codingapi/txlcn/protocol/message/event/SnowFlakeCreateEvent.java
@@ -1,0 +1,41 @@
+package com.codingapi.txlcn.protocol.message.event;
+
+import com.codingapi.txlcn.protocol.Protocoler;
+import com.codingapi.txlcn.protocol.message.Connection;
+import com.codingapi.txlcn.protocol.message.separate.SnowFlakeMessage;
+import com.codingapi.txlcn.tm.id.SnowflakeHandler;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * @author WhomHim
+ * @description SnowFlake 生成事件
+ * @date Create in 2020-8-14 22:13:12
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Slf4j
+public class SnowFlakeCreateEvent extends SnowFlakeMessage {
+
+    /**
+     * 事务组Id
+     */
+    private String groupId;
+
+    /**
+     * 日志主键
+     */
+    private long logId;
+
+    @Override
+    public void handle(ApplicationContext springContext, Protocoler protocoler, Connection connection) throws Exception {
+        super.handle(springContext, protocoler, connection);
+        this.groupId = SnowflakeHandler.generateGroupId();
+        this.logId = SnowflakeHandler.generateLogId();
+        log.info("request msg =>{}", instanceId);
+        protocoler.sendMsg(connection.getUniqueKey(), this);
+        log.info("SnowFlakeCreateEvent.send =>[groupId:{},logId:{}]", instanceId, logId);
+    }
+}

--- a/txlcn-tm/src/main/java/com/codingapi/txlcn/protocol/message/event/TransactionCreateEvent.java
+++ b/txlcn-tm/src/main/java/com/codingapi/txlcn/protocol/message/event/TransactionCreateEvent.java
@@ -5,6 +5,7 @@ import com.codingapi.txlcn.protocol.message.Connection;
 import com.codingapi.txlcn.protocol.message.separate.TransactionMessage;
 import com.codingapi.txlcn.tm.repository.TransactionGroupRepository;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
 
@@ -13,6 +14,7 @@ import org.springframework.context.ApplicationContext;
  * @date 2020/4/3
  * @description
  */
+@EqualsAndHashCode(callSuper = true)
 @Data
 @Slf4j
 public class TransactionCreateEvent extends TransactionMessage {

--- a/txlcn-tm/src/main/java/com/codingapi/txlcn/protocol/message/event/TransactionJoinEvent.java
+++ b/txlcn-tm/src/main/java/com/codingapi/txlcn/protocol/message/event/TransactionJoinEvent.java
@@ -5,6 +5,7 @@ import com.codingapi.txlcn.protocol.message.Connection;
 import com.codingapi.txlcn.protocol.message.separate.TransactionMessage;
 import com.codingapi.txlcn.tm.repository.TransactionGroupRepository;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
 
@@ -13,6 +14,7 @@ import org.springframework.context.ApplicationContext;
  * @date 2020/7/1
  * @description
  */
+@EqualsAndHashCode(callSuper = true)
 @Data
 @Slf4j
 public class TransactionJoinEvent extends TransactionMessage {

--- a/txlcn-tm/src/main/java/com/codingapi/txlcn/tm/id/Snowflake.java
+++ b/txlcn-tm/src/main/java/com/codingapi/txlcn/tm/id/Snowflake.java
@@ -1,4 +1,4 @@
-package com.codingapi.txlcn.tc.id;
+package com.codingapi.txlcn.tm.id;
 
 
 import java.io.Serializable;

--- a/txlcn-tm/src/main/java/com/codingapi/txlcn/tm/id/SnowflakeHandler.java
+++ b/txlcn-tm/src/main/java/com/codingapi/txlcn/tm/id/SnowflakeHandler.java
@@ -1,5 +1,7 @@
 package com.codingapi.txlcn.tm.id;
 
+import static com.codingapi.txlcn.tm.id.SnowflakeInitiator.getSnowflakeVo;
+
 /**
  * @author lorne
  * @date 2020/8/8
@@ -7,7 +9,8 @@ package com.codingapi.txlcn.tm.id;
  */
 public class SnowflakeHandler {
 
-    private static final Snowflake snowflake = SnowflakeHandler.createSnowflake((long) (Math.random() * 31));
+    private static final Snowflake snowflake =
+            SnowflakeHandler.createSnowflake(getSnowflakeVo().getWorkerId(), getSnowflakeVo().getDataCenterId());
 
     /**
      * 创建Twitter的Snowflake 算法生成器。
@@ -33,8 +36,8 @@ public class SnowflakeHandler {
      * @param workerId 终端ID
      * @return {@link Snowflake}
      */
-    public static Snowflake createSnowflake(long workerId) {
-        return new Snowflake(workerId, 0);
+    public static Snowflake createSnowflake(long workerId, long dataCenterId) {
+        return new Snowflake(workerId, dataCenterId);
     }
 
     /**

--- a/txlcn-tm/src/main/java/com/codingapi/txlcn/tm/id/SnowflakeHandler.java
+++ b/txlcn-tm/src/main/java/com/codingapi/txlcn/tm/id/SnowflakeHandler.java
@@ -1,16 +1,13 @@
-package com.codingapi.txlcn.tc.utils;
-
-import com.codingapi.txlcn.tc.id.Snowflake;
-
+package com.codingapi.txlcn.tm.id;
 
 /**
  * @author lorne
  * @date 2020/8/8
  * @description
  */
-public class IdUtils {
+public class SnowflakeHandler {
 
-    private static final Snowflake snowflake = IdUtils.createSnowflake((long) (Math.random() * 31));
+    private static final Snowflake snowflake = SnowflakeHandler.createSnowflake((long) (Math.random() * 31));
 
     /**
      * 创建Twitter的Snowflake 算法生成器。

--- a/txlcn-tm/src/main/java/com/codingapi/txlcn/tm/id/SnowflakeInitiator.java
+++ b/txlcn-tm/src/main/java/com/codingapi/txlcn/tm/id/SnowflakeInitiator.java
@@ -1,0 +1,136 @@
+package com.codingapi.txlcn.tm.id;
+
+
+import com.alibaba.fastjson.JSON;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import javax.annotation.PreDestroy;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 雪花算法初始化器
+ * 初始化snowflake的dataCenterId和workerId
+ * <p>
+ * 1.系统启动时生成默认dataCenterId和workerId，并尝试作为key存储到redis
+ * 2.如果存储成功，设置redis过期时间为24h，把当前dataCenterId和workerId传入snowflake
+ * 3.如果存储失败workerId自加1，并判断workerId不大于31，重复1步骤
+ * 4.定义一个定时器，每隔24h刷新redis的过期时间为24h
+ */
+@SuppressWarnings({"unchecked", "rawtypes", "ConstantConditions"})
+@Configuration
+@Slf4j
+public class SnowflakeInitiator {
+
+    private static final String prefixRedisKey = "SnowflakeRedisKey";
+
+    private static String snowflakeRedisKey;
+
+    private static long LockExpire = 60 * 60 * 24;
+
+    private static boolean stopTrying = false;
+
+    /**
+     * snowflake 的 dataCenterId 和 workerId
+     */
+    public static SnowflakeVo snowflakeVo;
+
+    private final RedisTemplate redisTemplate;
+
+    public SnowflakeInitiator(RedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Bean
+    public void init() {
+        if (tryInit()) {
+            log.debug("snowflake try Init create key,key:{}", JSON.toJSONString(snowflakeVo));
+            return;
+        }
+        if (stopTrying) {
+            log.debug("snowflake stop create key,key:{}", JSON.toJSONString(snowflakeVo));
+            return;
+        }
+        init();
+    }
+
+    /**
+     * 尝试保存 workId 和 dataCenterId 到 redis
+     *
+     * @return boolean
+     */
+    public boolean tryInit() {
+        snowflakeVo = nextKey(snowflakeVo);
+        snowflakeRedisKey = prefixRedisKey + "_" + snowflakeVo.getDataCenterId() + "_" + snowflakeVo.getWorkerId();
+        Boolean isNotHasKey = !redisTemplate.hasKey(snowflakeRedisKey);
+        Boolean isSetKey = redisTemplate.opsForValue().setIfAbsent(snowflakeRedisKey, 1, LockExpire, TimeUnit.SECONDS);
+        if (isNotHasKey && isSetKey) {
+            log.info("snowflake setIfAbsent key:{}", JSON.toJSONString(snowflakeVo));
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * 生成下一组不重复的 dataCenterId 和 workerId
+     *
+     * @return SnowflakeVo
+     */
+    private SnowflakeVo nextKey(SnowflakeVo snowflakeVo) {
+        if (snowflakeVo == null) {
+            return new SnowflakeVo(1L, 1L);
+        }
+
+        if (snowflakeVo.getWorkerId() < 31) {
+            // 如果workerId < 31
+            snowflakeVo.setWorkerId(snowflakeVo.getWorkerId() + 1);
+        } else {
+            // 如果workerId >= 31
+            if (snowflakeVo.getDataCenterId() < 31) {
+                // 如果workerId >= 31 && dataCenterId < 31
+                snowflakeVo.setDataCenterId(snowflakeVo.getDataCenterId() + 1);
+                snowflakeVo.setWorkerId(1L);
+            } else {
+                // 如果workerId >= 31 && dataCenterId >= 31
+                snowflakeVo.setDataCenterId(1L);
+                snowflakeVo.setWorkerId(1L);
+                stopTrying = true;
+            }
+        }
+        return snowflakeVo;
+    }
+
+    /**
+     * 重新设置过期时间，由定时任务调用
+     */
+    public void resetExpire() {
+        redisTemplate.expire(snowflakeRedisKey, (LockExpire - 600), TimeUnit.SECONDS);
+        log.info("reset the snowflakeRedisKey's resetExpire time,redisKey :{}", snowflakeRedisKey);
+    }
+
+    /**
+     * 容器销毁时主动删除 redis 注册记录，此方法不适用于强制终止 Spring 容器的场景，只作为补充优化
+     */
+    @PreDestroy
+    public void destroy() {
+        redisTemplate.delete(snowflakeRedisKey);
+    }
+
+    public static SnowflakeVo getSnowflakeVo() {
+        return snowflakeVo;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SnowflakeVo {
+        private Long dataCenterId;
+        private Long workerId;
+    }
+}

--- a/txlcn-tm/src/main/java/com/codingapi/txlcn/tm/id/SnowflakeSchedule.java
+++ b/txlcn-tm/src/main/java/com/codingapi/txlcn/tm/id/SnowflakeSchedule.java
@@ -1,0 +1,23 @@
+package com.codingapi.txlcn.tm.id;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author WhomHim
+ * @description
+ * @date Create in 2020-8-17 22:34:28
+ */
+@Component
+public class SnowflakeSchedule {
+    @Autowired
+    private SnowflakeInitiator snowflakeInitiator;
+
+    @Scheduled(fixedDelay = 1000 * 60 * 60 * 23)
+    private void snowflakeInitiator_ResetExpire() {
+        snowflakeInitiator.resetExpire();
+    }
+
+
+}

--- a/txlcn-tm/src/test/java/com/codingapi/txlcn/tm/id/SnowflakeHandlerTest.java
+++ b/txlcn-tm/src/test/java/com/codingapi/txlcn/tm/id/SnowflakeHandlerTest.java
@@ -1,4 +1,4 @@
-package com.codingapi.txlcn.tc.utils;
+package com.codingapi.txlcn.tm.id;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.util.Assert;
@@ -7,13 +7,13 @@ import org.springframework.util.StopWatch;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.codingapi.txlcn.tc.utils.IdUtils.generateLogId;
+import static com.codingapi.txlcn.tm.id.SnowflakeHandler.generateLogId;
 
 /**
  * @author WhomHim
  * @date Create in 2020-8-10 22:09:30
  */
-public class IdUtilsTest {
+public class SnowflakeHandlerTest {
 
     @Test
     public void id() {
@@ -28,4 +28,5 @@ public class IdUtilsTest {
         stopWatch.stop();
         Assert.isTrue(1000 == logSet.size(), "size must the same");
     }
+
 }


### PR DESCRIPTION
经过调研发现，雪花算法实际上是需要单例的，也就是说 workId 及 dataCenterId 需要不变才能保证每一次生成的 id 不重复。所以正确的做法应该是雪花算法部署在一个服务上，而其他需要生成 id 的服务对其进行调用。

本次 pr 做了以下变动：
- 当 TM 启动时，按照一定的策略生成 workId 及 dataCenterId 并保存在 redis 上，以防止多实例的情况
- 当 TC 启动时，连接成功时异步产生雪花算法生成事件通知 TM 去获取 ID
- 由于 TC 是异步去取得  ID 的，所以将 ID 放在了缓存里面，需要用到的时候再去取

