### PR TITLE
fix(sec): upgrade com.alibaba:fastjson to 1.2.83

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <txlcn-org.projectlombok.version>1.18.0</txlcn-org.projectlombok.version>
     <txlcn-spring-cloud.version>Finchley.SR2</txlcn-spring-cloud.version>
     <txlcn-io.netty.version>4.1.31.Final</txlcn-io.netty.version>
-    <txlcn-com.alibaba.fastjson.version>1.2.34</txlcn-com.alibaba.fastjson.version>
+    <txlcn-com.alibaba.fastjson.version>1.2.83</txlcn-com.alibaba.fastjson.version>
     <txlcn-guava.version>19.0</txlcn-guava.version>
     <txlcn-hessian.version>4.0.38</txlcn-hessian.version>
     <txlcn-protostuff.version>1.6.0</txlcn-protostuff.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.alibaba:fastjson 1.2.34
- [CVE-2022-25845](https://www.oscs1024.com/hd/CVE-2022-25845)


### What did I do？
Upgrade com.alibaba:fastjson from 1.2.34 to 1.2.83 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS