### PR TITLE
fix(sec): upgrade com.h2database:h2 to 2.1.210

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <txlcn-com.lmax.disruptor.version>3.4.2</txlcn-com.lmax.disruptor.version>
     <txlcn-commons-dbutils.version>1.7</txlcn-commons-dbutils.version>
     <txlcn-com.github.jsqlparser.version>3.2</txlcn-com.github.jsqlparser.version>
-    <txlcn-com.h2database.version>1.4.197</txlcn-com.h2database.version>
+    <txlcn-com.h2database.version>2.1.210</txlcn-com.h2database.version>
     <txlcn-hikari-cp.version>3.1.0</txlcn-hikari-cp.version>
 
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.h2database:h2 1.4.197
- [CVE-2018-14335](https://www.oscs1024.com/hd/CVE-2018-14335)


### What did I do？
Upgrade com.h2database:h2 from 1.4.197 to 2.1.210 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS